### PR TITLE
changed the position of lit-html to be dependent on own lib

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,19 @@
+{
+  "presets": [
+    [
+      "env",
+      {
+        "modules": false
+      }
+    ]
+  ],
+  "plugins": [
+    "external-helpers",
+    ["transform-runtime", {
+      "helpers": false,
+      "polyfill": false,
+      "regenerator": true
+    }],
+    ["transform-object-rest-spread", {"useBuiltIns": true}]
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,7 @@ typings/
 
 dist
 
+lib/lit-html
+
 test/unit/cases-es5
 test/unit/scripts-es5

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ node_js:
 before_install:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
-before_script:
-- cp -r node_modules/lit-html ../../lit-html
 script: npm test && npm run wct-sauce
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ node_js:
 before_install:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
-script: npm test && npm run wct-sauce
+script: npm test && npm run wct-sauce && npm run wct-sauce-ie
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ node_js:
 before_install:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
-script: npm test && npm run wct-sauce && npm run wct-sauce-ie
+script: npm test && npm run wct-sauce
 branches:
   only:
   - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.1.5 (2018-18-03)
+- Changed the position of lit-html to be dependent on own lib
+
 # v0.1.4 (2018-18-03)
 - Added `lib` on `files` in package.json
 - Cleaned up README

--- a/README.md
+++ b/README.md
@@ -490,9 +490,11 @@ It works on all major evergreen Browsers (Edge, Safari, Chrome, Firefox) as long
 set (make sure to add `webcomponents-lite` or `webcomponents-loader` and create the components after the
 `WebComponentsReady` event has been fired)
 
-It also works on IE 11, Safari 11, Safari 10.1, Safari 9, and Safari 8.
+It also works on IE 11, Safari 11, Safari 10.1.
 
-Still checking on IE 10, 9, 8 and Safari 7, 6. (Need polyfills for `Map` and `WeakMap` when using the webcomponents-lite polyfill and custom-element-es5-adapter).
+Still checking on IE 10, 9, 8 and Safari 9, 8, 7, 6. (Need polyfills for `Map` and `WeakMap` when using the webcomponents-lite polyfill and `custom-element-es5-adapter`).
+
+For IE 11. You need to use `lib/native-shim.es5.js` instead of `custom-element-es5-adapter` for it to work.
 
 
 ## Size

--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ It works on all major evergreen Browsers (Edge, Safari, Chrome, Firefox) as long
 set (make sure to add `webcomponents-lite` or `webcomponents-loader` and create the components after the
 `WebComponentsReady` event has been fired)
 
-It also works on IE 11, Safari 11, Safari 10.1.
+It also works on Safari 11, Safari 10.1.
 
 Still checking on IE 10, 9, 8 and Safari 9, 8, 7, 6. (Need polyfills for `Map` and `WeakMap` when using the webcomponents-lite polyfill and `custom-element-es5-adapter`).
 

--- a/element-lite-lit-only.js
+++ b/element-lite-lit-only.js
@@ -1,7 +1,7 @@
 /// <reference path="typings-project/global.d.ts"/>
 
 import { dedupingMixin } from './lib/deduping-mixin.js';
-import { render, html } from '../../lit-html/lib/lit-extended.js';
+import { render, html } from './lib/lit-html/lib/lit-extended.js';
 
 export { html };
 export const ElementLiteLitOnly = dedupingMixin(base => {

--- a/element-lite.js
+++ b/element-lite.js
@@ -2,7 +2,7 @@ import { ElementLiteBase } from './element-lite-base.js';
 import { ElementLiteStaticShadow } from './element-lite-static-shadow.js';
 import { ElementLiteLitOnly } from './element-lite-lit-only.js';
 import { dedupingMixin } from './lib/deduping-mixin.js';
-import { render, html } from '../../lit-html/lib/lit-extended.js';
+import { render, html } from './lib/lit-html/lib/lit-extended.js';
 
 export { html, ElementLiteBase, ElementLiteStaticShadow, ElementLiteLitOnly };
 export const ElementLite = dedupingMixin(base => {

--- a/lib/es6-symbol.js
+++ b/lib/es6-symbol.js
@@ -1,0 +1,4 @@
+// @ts-nocheck
+
+import Symbol from 'es6-symbol';
+if (!window.Symbol) window.Symbol = Symbol;

--- a/lib/native-shim.es5.js
+++ b/lib/native-shim.es5.js
@@ -1,0 +1,177 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+// @ts-nocheck
+
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+/**
+ * This shim allows elements written in, or compiled to, ES5 to work on native
+ * implementations of Custom Elements.
+ *
+ * ES5-style classes don't work with native Custom Elements because the
+ * HTMLElement constructor uses the value of `new.target` to look up the custom
+ * element definition for the currently called constructor. `new.target` is only
+ * set when `new` is called and is only propagated via super() calls. super()
+ * is not emulatable in ES5. The pattern of `SuperClass.call(this)`` only works
+ * when extending other ES5-style classes, and does not propagate `new.target`.
+ *
+ * This shim allows the native HTMLElement constructor to work by generating and
+ * registering a stand-in class instead of the users custom element class. This
+ * stand-in class's constructor has an actual call to super().
+ * `customElements.define()` and `customElements.get()` are both overridden to
+ * hide this stand-in class from users.
+ *
+ * In order to create instance of the user-defined class, rather than the stand
+ * in, the stand-in's constructor swizzles its instances prototype and invokes
+ * the user-defined constructor. When the user-defined constructor is called
+ * directly it creates an instance of the stand-in class to get a real extension
+ * of HTMLElement and returns that.
+ *
+ * There are two important constructors: A patched HTMLElement constructor, and
+ * the StandInElement constructor. They both will be called to create an element
+ * but which is called first depends on whether the browser creates the element
+ * or the user-defined constructor is called directly. The variables
+ * `browserConstruction` and `userConstruction` control the flow between the
+ * two constructors.
+ *
+ * This shim should be better than forcing the polyfill because:
+ *   1. It's smaller
+ *   2. All reaction timings are the same as native (mostly synchronous)
+ *   3. All reaction triggering DOM operations are automatically supported
+ *
+ * There are some restrictions and requirements on ES5 constructors:
+ *   1. All constructors in a inheritance hierarchy must be ES5-style, so that
+ *      they can be called with Function.call(). This effectively means that the
+ *      whole application must be compiled to ES5.
+ *   2. Constructors must return the value of the emulated super() call. Like
+ *      `return SuperClass.call(this)`
+ *   3. The `this` reference should not be used before the emulated super() call
+ *      just like `this` is illegal to use before super() in ES6.
+ *   4. Constructors should not create other custom elements before the emulated
+ *      super() call. This is the same restriction as with native custom
+ *      elements.
+ *
+ *  Compiling valid class-based custom elements to ES5 will satisfy these
+ *  requirements with the latest version of popular transpilers.
+ */
+(function () {
+
+  // Do nothing if `customElements` does not exist.
+  if (!window.customElements) { return; }
+
+  var NativeHTMLElement = window.HTMLElement;
+  var nativeDefine = window.customElements.define;
+  var nativeGet = window.customElements.get;
+
+  /**
+   * Map of user-provided constructors to tag names.
+   *
+   * @type {Map<Function, string>}
+   */
+  var tagnameByConstructor = new Map();
+
+  /**
+   * Map of tag names to user-provided constructors.
+   *
+   * @type {Map<string, Function>}
+   */
+  var constructorByTagname = new Map();
+
+  /**
+   * Whether the constructors are being called by a browser process, ie parsing
+   * or createElement.
+   */
+  var browserConstruction = false;
+
+  /**
+   * Whether the constructors are being called by a user-space process, ie
+   * calling an element constructor.
+   */
+  var userConstruction = false;
+
+  window.HTMLElement = function () {
+    if (!browserConstruction) {
+      var tagname = tagnameByConstructor.get(this.constructor);
+      var fakeClass = nativeGet.call(window.customElements, tagname);
+
+      // Make sure that the fake constructor doesn't call back to this constructor
+      userConstruction = true;
+      var instance = new (fakeClass)(); // eslint-disable-line
+      return instance;
+    }
+    // Else do nothing. This will be reached by ES5-style classes doing
+    // HTMLElement.call() during initialization
+    browserConstruction = false;
+  };
+  // By setting the patched HTMLElement's prototype property to the native
+  // HTMLElement's prototype we make sure that:
+  //     document.createElement('a') instanceof HTMLElement
+  // works because instanceof uses HTMLElement.prototype, which is on the
+  // ptototype chain of built-in elements.
+  window.HTMLElement.prototype = NativeHTMLElement.prototype;
+
+  var define = function (tagname, elementClass) {
+    var elementProto = elementClass.prototype;
+    var StandInElement = (function (NativeHTMLElement) {
+      function StandInElement () {
+        // Call the native HTMLElement constructor, this gives us the
+        // under-construction instance as `this`:
+        NativeHTMLElement.call(this);
+
+        // The prototype will be wrong up because the browser used our fake
+        // class, so fix it:
+        Object.setPrototypeOf(this, elementProto);
+
+        if (!userConstruction) {
+          // Make sure that user-defined constructor bottom's out to a do-nothing
+          // HTMLElement() call
+          browserConstruction = true;
+          // Call the user-defined constructor on our instance:
+          elementClass.call(this);
+        }
+        userConstruction = false;
+      }
+
+      if ( NativeHTMLElement ) StandInElement.__proto__ = NativeHTMLElement;
+      StandInElement.prototype = Object.create( NativeHTMLElement && NativeHTMLElement.prototype );
+      StandInElement.prototype.constructor = StandInElement;
+
+      return StandInElement;
+    }(NativeHTMLElement));
+    var standInProto = StandInElement.prototype;
+    StandInElement.observedAttributes = elementClass.observedAttributes;
+    standInProto.connectedCallback = elementProto.connectedCallback;
+    standInProto.disconnectedCallback = elementProto.disconnectedCallback;
+    standInProto.attributeChangedCallback = elementProto.attributeChangedCallback;
+    standInProto.adoptedCallback = elementProto.adoptedCallback;
+
+    tagnameByConstructor.set(elementClass, tagname);
+    constructorByTagname.set(tagname, elementClass);
+    nativeDefine.call(window.customElements, tagname, StandInElement);
+  };
+
+  var get = function (tagname) { return constructorByTagname.get(tagname); };
+
+  // Workaround for Safari bug where patching customElements can be lost, likely
+  // due to native wrapper garbage collection issue
+  Object.defineProperty(window, 'customElements',
+    {value: window.customElements, configurable: true, writable: true});
+  Object.defineProperty(window.customElements, 'define',
+    {value: define, configurable: true, writable: true});
+  Object.defineProperty(window.customElements, 'get',
+    {value: get, configurable: true, writable: true});
+})();
+
+})));

--- a/lib/native-shim.js
+++ b/lib/native-shim.js
@@ -1,0 +1,164 @@
+// @ts-nocheck
+
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+/**
+ * This shim allows elements written in, or compiled to, ES5 to work on native
+ * implementations of Custom Elements.
+ *
+ * ES5-style classes don't work with native Custom Elements because the
+ * HTMLElement constructor uses the value of `new.target` to look up the custom
+ * element definition for the currently called constructor. `new.target` is only
+ * set when `new` is called and is only propagated via super() calls. super()
+ * is not emulatable in ES5. The pattern of `SuperClass.call(this)`` only works
+ * when extending other ES5-style classes, and does not propagate `new.target`.
+ *
+ * This shim allows the native HTMLElement constructor to work by generating and
+ * registering a stand-in class instead of the users custom element class. This
+ * stand-in class's constructor has an actual call to super().
+ * `customElements.define()` and `customElements.get()` are both overridden to
+ * hide this stand-in class from users.
+ *
+ * In order to create instance of the user-defined class, rather than the stand
+ * in, the stand-in's constructor swizzles its instances prototype and invokes
+ * the user-defined constructor. When the user-defined constructor is called
+ * directly it creates an instance of the stand-in class to get a real extension
+ * of HTMLElement and returns that.
+ *
+ * There are two important constructors: A patched HTMLElement constructor, and
+ * the StandInElement constructor. They both will be called to create an element
+ * but which is called first depends on whether the browser creates the element
+ * or the user-defined constructor is called directly. The variables
+ * `browserConstruction` and `userConstruction` control the flow between the
+ * two constructors.
+ *
+ * This shim should be better than forcing the polyfill because:
+ *   1. It's smaller
+ *   2. All reaction timings are the same as native (mostly synchronous)
+ *   3. All reaction triggering DOM operations are automatically supported
+ *
+ * There are some restrictions and requirements on ES5 constructors:
+ *   1. All constructors in a inheritance hierarchy must be ES5-style, so that
+ *      they can be called with Function.call(). This effectively means that the
+ *      whole application must be compiled to ES5.
+ *   2. Constructors must return the value of the emulated super() call. Like
+ *      `return SuperClass.call(this)`
+ *   3. The `this` reference should not be used before the emulated super() call
+ *      just like `this` is illegal to use before super() in ES6.
+ *   4. Constructors should not create other custom elements before the emulated
+ *      super() call. This is the same restriction as with native custom
+ *      elements.
+ *
+ *  Compiling valid class-based custom elements to ES5 will satisfy these
+ *  requirements with the latest version of popular transpilers.
+ */
+(() => {
+  'use strict';
+
+  // Do nothing if `customElements` does not exist.
+  if (!window.customElements) return;
+
+  const NativeHTMLElement = window.HTMLElement;
+  const nativeDefine = window.customElements.define;
+  const nativeGet = window.customElements.get;
+
+  /**
+   * Map of user-provided constructors to tag names.
+   *
+   * @type {Map<Function, string>}
+   */
+  const tagnameByConstructor = new Map();
+
+  /**
+   * Map of tag names to user-provided constructors.
+   *
+   * @type {Map<string, Function>}
+   */
+  const constructorByTagname = new Map();
+
+  /**
+   * Whether the constructors are being called by a browser process, ie parsing
+   * or createElement.
+   */
+  let browserConstruction = false;
+
+  /**
+   * Whether the constructors are being called by a user-space process, ie
+   * calling an element constructor.
+   */
+  let userConstruction = false;
+
+  window.HTMLElement = function () {
+    if (!browserConstruction) {
+      const tagname = tagnameByConstructor.get(this.constructor);
+      const fakeClass = nativeGet.call(window.customElements, tagname);
+
+      // Make sure that the fake constructor doesn't call back to this constructor
+      userConstruction = true;
+      const instance = new (fakeClass)(); // eslint-disable-line
+      return instance;
+    }
+    // Else do nothing. This will be reached by ES5-style classes doing
+    // HTMLElement.call() during initialization
+    browserConstruction = false;
+  };
+  // By setting the patched HTMLElement's prototype property to the native
+  // HTMLElement's prototype we make sure that:
+  //     document.createElement('a') instanceof HTMLElement
+  // works because instanceof uses HTMLElement.prototype, which is on the
+  // ptototype chain of built-in elements.
+  window.HTMLElement.prototype = NativeHTMLElement.prototype;
+
+  const define = (tagname, elementClass) => {
+    const elementProto = elementClass.prototype;
+    const StandInElement = class extends NativeHTMLElement {
+      constructor () {
+        // Call the native HTMLElement constructor, this gives us the
+        // under-construction instance as `this`:
+        super();
+
+        // The prototype will be wrong up because the browser used our fake
+        // class, so fix it:
+        Object.setPrototypeOf(this, elementProto);
+
+        if (!userConstruction) {
+          // Make sure that user-defined constructor bottom's out to a do-nothing
+          // HTMLElement() call
+          browserConstruction = true;
+          // Call the user-defined constructor on our instance:
+          elementClass.call(this);
+        }
+        userConstruction = false;
+      }
+    };
+    const standInProto = StandInElement.prototype;
+    StandInElement.observedAttributes = elementClass.observedAttributes;
+    standInProto.connectedCallback = elementProto.connectedCallback;
+    standInProto.disconnectedCallback = elementProto.disconnectedCallback;
+    standInProto.attributeChangedCallback = elementProto.attributeChangedCallback;
+    standInProto.adoptedCallback = elementProto.adoptedCallback;
+
+    tagnameByConstructor.set(elementClass, tagname);
+    constructorByTagname.set(tagname, elementClass);
+    nativeDefine.call(window.customElements, tagname, StandInElement);
+  };
+
+  const get = (tagname) => constructorByTagname.get(tagname);
+
+  // Workaround for Safari bug where patching customElements can be lost, likely
+  // due to native wrapper garbage collection issue
+  Object.defineProperty(window, 'customElements',
+    {value: window.customElements, configurable: true, writable: true});
+  Object.defineProperty(window.customElements, 'define',
+    {value: define, configurable: true, writable: true});
+  Object.defineProperty(window.customElements, 'get',
+    {value: get, configurable: true, writable: true});
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@littleq/element-lite",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -97,12 +97,6 @@
           "dev": true
         }
       }
-    },
-    "@comandeer/babel-plugin-banner": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@comandeer/babel-plugin-banner/-/babel-plugin-banner-1.0.0.tgz",
-      "integrity": "sha1-QLzOC77ghLWwJUWjNjXQU8JINW8=",
-      "dev": true
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -601,28 +595,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        }
-      }
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -1129,18 +1101,6 @@
         }
       }
     },
-    "babel-helper-evaluate-path": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.3.0.tgz",
-      "integrity": "sha512-dRFlMTqUJRGzx5a2smKxmptDdNCXKSkPcXWzKLwAV72hvIZumrd/0z9RcewHkr7PmAEq+ETtpD1GK6wZ6ZUXzw==",
-      "dev": true
-    },
-    "babel-helper-flip-expressions": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.3.0.tgz",
-      "integrity": "sha512-kNGohWmtAG3b7tN1xocRQ5rsKkH/hpvZsMiGOJ1VwGJKhnwzR5KlB3rvKBaBPl5/IGHcopB2JN+r1SUEX1iMAw==",
-      "dev": true
-    },
     "babel-helper-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
@@ -1174,24 +1134,6 @@
         "babel-types": "6.26.0"
       }
     },
-    "babel-helper-is-nodes-equiv": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
-      "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
-      "dev": true
-    },
-    "babel-helper-is-void-0": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.3.0.tgz",
-      "integrity": "sha512-JVqdX8y7Rf/x4NwbqtUI7mdQjL9HWoDnoAEQ8Gv8oxzjvbJv+n75f7l36m9Y8C7sCUltX3V5edndrp7Hp1oSXQ==",
-      "dev": true
-    },
-    "babel-helper-mark-eval-scopes": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.3.0.tgz",
-      "integrity": "sha512-nrho5Dg4vl0VUgURVpGpEGiwbst5JX7efIyDHFxmkCx/ocQFnrPt8ze9Kxl6TKjR29bJ7D/XKY1NMlSxOQJRbQ==",
-      "dev": true
-    },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
@@ -1221,12 +1163,6 @@
         }
       }
     },
-    "babel-helper-remove-or-void": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.3.0.tgz",
-      "integrity": "sha512-D68W1M3ibCcbg0ysh3ww4/O0g10X1CXK720oOuR8kpfY7w0yP4tVcpK7zDmI1JecynycTQYAZ1rhLJo9aVtIKQ==",
-      "dev": true
-    },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
@@ -1240,12 +1176,6 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0"
       }
-    },
-    "babel-helper-to-multiple-sequence-expressions": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.3.0.tgz",
-      "integrity": "sha512-1uCrBD+EAaMnAYh7hc944n8Ga19y3daEnoXWPYDvFVsxMCc1l8aDjksApaCEaNSSuewq8BEcff47Cy1PbLg2Gw==",
-      "dev": true
     },
     "babel-helpers": {
       "version": "6.24.1",
@@ -1264,101 +1194,6 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-minify-builtins": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.3.0.tgz",
-      "integrity": "sha512-MqhSHlxkmgURqj3144qPksbZ/qof1JWdumcbucc4tysFcf3P3V3z3munTevQgKEFNMd8F5/ECGnwb63xogLjAg==",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "0.3.0"
-      }
-    },
-    "babel-plugin-minify-constant-folding": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.3.0.tgz",
-      "integrity": "sha512-1XeRpx+aY1BuNY6QU/cm6P+FtEi3ar3XceYbmC+4q4W+2Ewq5pL7V68oHg1hKXkBIE0Z4/FjSoHz6vosZLOe/A==",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "0.3.0"
-      }
-    },
-    "babel-plugin-minify-dead-code-elimination": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.3.0.tgz",
-      "integrity": "sha512-SjM2Fzg85YZz+q/PNJ/HU4O3W98FKFOiP9K5z3sfonlamGOzvZw3Eup2OTiEBsbbqTeY8yzNCAv3qpJRYCgGmw==",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "0.3.0",
-        "babel-helper-mark-eval-scopes": "0.3.0",
-        "babel-helper-remove-or-void": "0.3.0",
-        "lodash.some": "4.6.0"
-      }
-    },
-    "babel-plugin-minify-flip-comparisons": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.3.0.tgz",
-      "integrity": "sha512-B8lK+ekcpSNVH7PZpWDe5nC5zxjRiiT4nTsa6h3QkF3Kk6y9qooIFLemdGlqBq6j0zALEnebvCpw8v7gAdpgnw==",
-      "dev": true,
-      "requires": {
-        "babel-helper-is-void-0": "0.3.0"
-      }
-    },
-    "babel-plugin-minify-guarded-expressions": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.3.0.tgz",
-      "integrity": "sha512-O+6CvF5/Ttsth3LMg4/BhyvVZ82GImeKMXGdVRQGK/8jFiP15EjRpdgFlxv3cnqRjqdYxLCS6r28VfLpb9C/kA==",
-      "dev": true,
-      "requires": {
-        "babel-helper-flip-expressions": "0.3.0"
-      }
-    },
-    "babel-plugin-minify-infinity": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.3.0.tgz",
-      "integrity": "sha512-Sj8ia3/w9158DWieUxU6/VvnYVy59geeFEkVgLZYBE8EBP+sN48tHtBM/jSgz0ejEdBlcfqJ6TnvPmVXTzR2BQ==",
-      "dev": true
-    },
-    "babel-plugin-minify-mangle-names": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.3.0.tgz",
-      "integrity": "sha512-PYTonhFWURsfAN8achDwvR5Xgy6EeTClLz+fSgGRqjAIXb0OyFm3/xfccbQviVi1qDXmlSnt6oJhBg8KE4Fn7Q==",
-      "dev": true,
-      "requires": {
-        "babel-helper-mark-eval-scopes": "0.3.0"
-      }
-    },
-    "babel-plugin-minify-numeric-literals": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.3.0.tgz",
-      "integrity": "sha512-TgZj6ay8zDw74AS3yiIfoQ8vRSNJisYO/Du60S8nPV7EW7JM6fDMx5Sar6yVHlVuuwNgvDUBh191K33bVrAhpg==",
-      "dev": true
-    },
-    "babel-plugin-minify-replace": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.3.0.tgz",
-      "integrity": "sha512-VR6tTg2Lt0TicHIOw04fsUtpPw7RaRP8PC8YzSFwEixnzvguZjZJoL7TgG7ZyEWQD1cJ96UezswECmFNa815bg==",
-      "dev": true
-    },
-    "babel-plugin-minify-simplify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.3.0.tgz",
-      "integrity": "sha512-2M16ytQOCqBi7bYMu4DCWn8e6KyFCA108F6+tVrBJxOmm5u2sOmTFEa8s94tR9RHRRNYmcUf+rgidfnzL3ik9Q==",
-      "dev": true,
-      "requires": {
-        "babel-helper-flip-expressions": "0.3.0",
-        "babel-helper-is-nodes-equiv": "0.0.1",
-        "babel-helper-to-multiple-sequence-expressions": "0.3.0"
-      }
-    },
-    "babel-plugin-minify-type-constructors": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.3.0.tgz",
-      "integrity": "sha512-XRXpvsUCPeVw9YEUw+9vSiugcSZfow81oIJT0yR9s8H4W7yJ6FHbImi5DJHoL8KcDUjYnL9wYASXk/fOkbyR6Q==",
-      "dev": true,
-      "requires": {
-        "babel-helper-is-void-0": "0.3.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1594,39 +1429,6 @@
         }
       }
     },
-    "babel-plugin-transform-inline-consecutive-adds": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.3.0.tgz",
-      "integrity": "sha512-iZsYAIjYLLfLK0yN5WVT7Xf7Y3wQ9Z75j9A8q/0IglQSpUt2ppTdHlwl/GeaXnxdaSmsxBu861klbTBbv2n+RA==",
-      "dev": true
-    },
-    "babel-plugin-transform-member-expression-literals": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.0.tgz",
-      "integrity": "sha512-bxtac+8w755ctVeDs4vU98RhWY49eW1wO02HAN+eirZYSKk/dVrKONIznXbHmxWKxT4UX1rpTKOCyezuzLpbTw==",
-      "dev": true
-    },
-    "babel-plugin-transform-merge-sibling-variables": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.0.tgz",
-      "integrity": "sha512-9G1URVEEKoQLDqe0GwqYudECN7kE/q0OCNo5TiD1iwWnnaKi97xY915l5r2KKUvNflXEm9c3faNWknSXYQ7h6Q==",
-      "dev": true
-    },
-    "babel-plugin-transform-minify-booleans": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.0.tgz",
-      "integrity": "sha512-JtpyTRyF+wF/r7GSxpRbNCrVve5M/aCC8xoGcnFItaPUDqjxKmFYvBzMc9u+g0lgo8NWjuZLc16MYaIwkHKD/A==",
-      "dev": true
-    },
-    "babel-plugin-transform-property-literals": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.0.tgz",
-      "integrity": "sha512-B8s+71+4DPye9+pmZiPGgLPy3YqcmIuvE/9UcZLczPlwL5ALwF6qRUdLC3Fk17NhL6jxp4u33ZVZ8R4kvASPzw==",
-      "dev": true,
-      "requires": {
-        "esutils": "2.0.2"
-      }
-    },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
@@ -1636,39 +1438,6 @@
         "regenerator-transform": "0.10.1"
       }
     },
-    "babel-plugin-transform-regexp-constructors": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.3.0.tgz",
-      "integrity": "sha512-h92YHzyl042rb0naKO8frTHntpRFwRgKkfWD8602kFHoQingjJNtbvZzvxqHncJ6XmKVyYvfrBpDOSkCTDIIxw==",
-      "dev": true
-    },
-    "babel-plugin-transform-remove-console": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.0.tgz",
-      "integrity": "sha512-mck9//yGTwObqqqDzY/sISO88/5/XfIB3ILb4uJLXk2xq124NT4yQVjFSRgVSbLcNq8OyBAn2acxKUqg4W/okQ==",
-      "dev": true
-    },
-    "babel-plugin-transform-remove-debugger": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.0.tgz",
-      "integrity": "sha512-i/HWGjsmL2d1N2dl+eIzf44XpSP5v7hi1/GXB0xzom9kjrU8js3T8Kadizn95ZxfHK592Vg8P4JJWP/fvimEWw==",
-      "dev": true
-    },
-    "babel-plugin-transform-remove-undefined": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.3.0.tgz",
-      "integrity": "sha512-TYGQucc8iP3LJwN3kDZLEz5aa/2KuFrqpT+s8f8NnHsBU1sAgR3y8Opns0xhC+smyDYWscqFCKM1gbkWQOhhnw==",
-      "dev": true,
-      "requires": {
-        "babel-helper-evaluate-path": "0.3.0"
-      }
-    },
-    "babel-plugin-transform-simplify-comparison-operators": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.0.tgz",
-      "integrity": "sha512-EJyfYeph0CSekwQuwWVwJqy2go/bETkR95iaWQ/HTUis7tkCGNYmXngaFzuIXdmoPXfvmXYCvAXR4/93hqHVjw==",
-      "dev": true
-    },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
@@ -1677,43 +1446,6 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-undefined-to-void": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.0.tgz",
-      "integrity": "sha512-AVDVEmp0S9mbF1O8zekWbsOOmqnR08PZah5NRZJqSvJnFgiL0ep4Lwo4EymH8OieJR2QgQdR3q71TNW+wiVn4g==",
-      "dev": true
-    },
-    "babel-preset-minify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.3.0.tgz",
-      "integrity": "sha512-+VV2GWEyak3eDOmzT1DDMuqHrw3VbE9nBNkx2LLVs4pH/Me32ND8DRpVDd8IRvk1xX5p75nygyRPtkMh6GIAbQ==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-minify-builtins": "0.3.0",
-        "babel-plugin-minify-constant-folding": "0.3.0",
-        "babel-plugin-minify-dead-code-elimination": "0.3.0",
-        "babel-plugin-minify-flip-comparisons": "0.3.0",
-        "babel-plugin-minify-guarded-expressions": "0.3.0",
-        "babel-plugin-minify-infinity": "0.3.0",
-        "babel-plugin-minify-mangle-names": "0.3.0",
-        "babel-plugin-minify-numeric-literals": "0.3.0",
-        "babel-plugin-minify-replace": "0.3.0",
-        "babel-plugin-minify-simplify": "0.3.0",
-        "babel-plugin-minify-type-constructors": "0.3.0",
-        "babel-plugin-transform-inline-consecutive-adds": "0.3.0",
-        "babel-plugin-transform-member-expression-literals": "6.9.0",
-        "babel-plugin-transform-merge-sibling-variables": "6.9.0",
-        "babel-plugin-transform-minify-booleans": "6.9.0",
-        "babel-plugin-transform-property-literals": "6.9.0",
-        "babel-plugin-transform-regexp-constructors": "0.3.0",
-        "babel-plugin-transform-remove-console": "6.9.0",
-        "babel-plugin-transform-remove-debugger": "6.9.0",
-        "babel-plugin-transform-remove-undefined": "0.3.0",
-        "babel-plugin-transform-simplify-comparison-operators": "6.9.0",
-        "babel-plugin-transform-undefined-to-void": "6.9.0",
-        "lodash.isplainobject": "4.0.6"
       }
     },
     "babel-register": {
@@ -2493,24 +2225,6 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true,
       "optional": true
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      },
-      "dependencies": {
-        "lazy-cache": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-          "dev": true
-        }
-      }
     },
     "chai": {
       "version": "4.1.2",
@@ -6995,12 +6709,6 @@
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
-    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -7016,12 +6724,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
-    },
-    "lodash.some": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
       "dev": true
     },
     "lodash.template": {
@@ -7053,12 +6755,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
       "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-      "dev": true
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "loose-envify": {
@@ -9939,15 +9635,6 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "requires": {
-        "align-text": "0.1.4"
-      }
-    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -9994,20 +9681,6 @@
         }
       }
     },
-    "rollup-plugin-babel-minify": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-babel-minify/-/rollup-plugin-babel-minify-4.0.0.tgz",
-      "integrity": "sha512-aqQTNCjrYZrWogHVpPQPVFRB/oKT9pGQzW8M/l3lRRuNz1zPtsYR/3shd5/SA8Msfb4HIytBEFUOQBCMoVVx6Q==",
-      "dev": true,
-      "requires": {
-        "@comandeer/babel-plugin-banner": "1.0.0",
-        "babel-core": "6.26.0",
-        "babel-preset-minify": "0.3.0",
-        "depd": "1.1.2",
-        "magic-string": "0.22.5",
-        "semver": "5.5.0"
-      }
-    },
     "rollup-plugin-buble": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-buble/-/rollup-plugin-buble-0.19.2.tgz",
@@ -10035,69 +9708,6 @@
           "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.1.tgz",
           "integrity": "sha512-7HgCgz1axW7w5aOvgOQkoR1RMBkllygJrssU3BvymKQ95lxXYv6Pon17fBRDm9qhkvXZGijOULoSF9ShOk/ZLg==",
           "dev": true
-        }
-      }
-    },
-    "rollup-plugin-minify": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-minify/-/rollup-plugin-minify-1.0.3.tgz",
-      "integrity": "sha1-PGTb4ytVJXDrJg+gIflAEOWRkLI=",
-      "dev": true,
-      "requires": {
-        "uglify-js": "2.8.29"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          }
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
         }
       }
     },
@@ -12219,13 +11829,6 @@
         "source-map": "0.6.1"
       }
     },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
-    },
     "uglifyjs-webpack-plugin": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.2.tgz",
@@ -13598,12 +13201,6 @@
       "requires": {
         "string-width": "2.1.1"
       }
-    },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true
     },
     "winston": {
       "version": "2.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@littleq/element-lite",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1069,6 +1069,17 @@
         }
       }
     },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
@@ -1099,6 +1110,17 @@
           "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
           "dev": true
         }
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -1163,6 +1185,19 @@
         }
       }
     },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
@@ -1193,6 +1228,59 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-external-helpers": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
+      "integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
         "babel-runtime": "6.26.0"
       }
     },
@@ -1333,6 +1421,28 @@
         "babel-types": "6.26.0"
       }
     },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
@@ -1429,6 +1539,27 @@
         }
       }
     },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
@@ -1436,6 +1567,15 @@
       "dev": true,
       "requires": {
         "regenerator-transform": "0.10.1"
+      }
+    },
+    "babel-plugin-transform-runtime": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1446,6 +1586,56 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
+      }
+    },
+    "babel-preset-env": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "2.11.3",
+        "invariant": "2.2.2",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "2.11.3",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+          "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000815",
+            "electron-to-chromium": "1.3.36"
+          }
+        }
       }
     },
     "babel-register": {
@@ -2211,6 +2401,12 @@
       "version": "1.0.30000813",
       "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000813.tgz",
       "integrity": "sha1-4KHGA/iICteHsqNWUrJzPzKl4po=",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000815",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000815.tgz",
+      "integrity": "sha512-PGSOPK6gFe5fWd+eD0u2bG0aOsN1qC4B1E66tl3jOsIoKkTIcBYAc2+O6AeNzKW8RsFykWgnhkTlfOyuTzgI9A==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -3119,6 +3315,14 @@
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
     },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "requires": {
+        "es5-ext": "0.10.41"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -3719,11 +3923,40 @@
         "is-symbol": "1.0.1"
       }
     },
+    "es5-ext": {
+      "version": "0.10.41",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.41.tgz",
+      "integrity": "sha512-MYK02wXfwTMie5TEJWPolgOsXEmz7wKCQaGzgmRjZOoV6VLG8I5dSv2bn6AOClXhK64gnSQTQ9W9MKvx87J4gw==",
+      "requires": {
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.41",
+        "es6-symbol": "3.1.1"
+      }
+    },
     "es6-promise": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
       "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
       "dev": true
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.41"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -7308,6 +7541,11 @@
       "integrity": "sha512-nJmSswG4As/MkRq7QZFuH/sf/yuv8ODdMZrY4Bedjp77a5MK4A6s7YbBB64c9u79EBUOfXUXBvArmvzTD0X+6g==",
       "dev": true
     },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
     "nice-try": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
@@ -9678,6 +9916,33 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
           "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
+        }
+      }
+    },
+    "rollup-plugin-babel": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-3.0.3.tgz",
+      "integrity": "sha512-5kzM/Rr4jQSRPLc2eN5NuD+CI/6AAy7S1O18Ogu4U3nq1Q42VJn0C9EMtqnvxtfwf1XrezOtdA9ro1VZI5B0mA==",
+      "dev": true,
+      "requires": {
+        "rollup-pluginutils": "1.5.2"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
+          "integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
+          "dev": true
+        },
+        "rollup-pluginutils": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
+          "integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+          "dev": true,
+          "requires": {
+            "estree-walker": "0.2.1",
+            "minimatch": "3.0.4"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@littleq/element-lite",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A take on using lit-html and polymer's properties-mixin",
   "main": "dist/element-lite.cjs.js",
   "module": "element-lite.js",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "wct-firefox": "./node_modules/.bin/wct --npm --configFile wct-firefox.conf.json",
     "wct-prod": "./node_modules/.bin/wct --npm --configFile wct-prod.conf.json",
     "wct-sauce": "./node_modules/.bin/wct --npm --configFile wct-sauce.conf.json",
+    "wct-sauce-ie": "./node_modules/.bin/wct --npm --configFile wct-sauce-ie.conf.json",
     "test": "npm run semistandard && npm run size && npm run wct-prod",
     "build": "./node_modules/.bin/rollup -c",
     "pretest": "npm run build",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "ignore": [
       "test/*",
       "dist/*",
-      "lib/native-shim.es5.js"
+      "polyfills/*"
     ],
     "env": [
       "mocha"
@@ -74,11 +74,16 @@
   "dependencies": {
     "@webcomponents/shadycss": "^1.1.1",
     "@webcomponents/webcomponentsjs": "^1.1.0",
+    "es6-symbol": "^3.1.1",
     "lit-html": "^0.9.0"
   },
   "devDependencies": {
     "@polymer/iron-test-helpers": "0.0.3",
     "babel-eslint": "^8.2.1",
+    "babel-plugin-external-helpers": "^6.22.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-env": "^1.6.1",
     "chai": "^4.1.2",
     "eslint": "^4.16.0",
     "eslint-config-semistandard": "^12.0.0",
@@ -93,6 +98,7 @@
     "lodash": "^3.10.1",
     "mocha": "^5.0.4",
     "rollup": "^0.57.0",
+    "rollup-plugin-babel": "^3.0.3",
     "rollup-plugin-buble": "^0.19.2",
     "rollup-plugin-commonjs": "^9.1.0",
     "rollup-plugin-node-resolve": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "browser": "dist/element-lite.umd.js",
   "scripts": {
     "size": "./node_modules/.bin/size-limit",
+    "copy": "cp -r ./node_modules/lit-html lib/lit-html",
+    "postinstall": "npm run copy",
     "semistandard": "./node_modules/.bin/semistandard",
     "wct": "npm run pretest && ./node_modules/.bin/wct --npm",
     "wct-firefox": "./node_modules/.bin/wct --npm --configFile wct-firefox.conf.json",
@@ -54,7 +56,7 @@
     },
     {
       "path": "element-lite.js",
-      "limit": "5.5KB"
+      "limit": "5.6KB"
     }
   ],
   "semistandard": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "parser": "babel-eslint",
     "ignore": [
       "test/*",
-      "dist/*"
+      "dist/*",
+      "lib/native-shim.es5.js"
     ],
     "env": [
       "mocha"

--- a/polyfills/es6-symbol.js
+++ b/polyfills/es6-symbol.js
@@ -1,0 +1,343 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) {
+  return typeof obj;
+} : function (obj) {
+  return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+};
+
+var validTypes = { object: true, symbol: true };
+
+var isImplemented = function isImplemented() {
+	if (typeof Symbol !== 'function') return false;
+	try {
+	} catch (e) {
+		return false;
+	}
+
+	// Return 'true' also for polyfills
+	if (!validTypes[_typeof(Symbol.iterator)]) return false;
+	if (!validTypes[_typeof(Symbol.toPrimitive)]) return false;
+	if (!validTypes[_typeof(Symbol.toStringTag)]) return false;
+
+	return true;
+};
+
+function createCommonjsModule(fn, module) {
+	return module = { exports: {} }, fn(module, module.exports), module.exports;
+}
+
+var isImplemented$1 = function isImplemented() {
+	var assign = Object.assign,
+	    obj;
+	if (typeof assign !== "function") return false;
+	obj = { foo: "raz" };
+	assign(obj, { bar: "dwa" }, { trzy: "trzy" });
+	return obj.foo + obj.bar + obj.trzy === "razdwatrzy";
+};
+
+var isImplemented$2 = function isImplemented() {
+	try {
+		return true;
+	} catch (e) {
+		return false;
+	}
+};
+
+// eslint-disable-next-line no-empty-function
+
+var noop = function noop() {};
+
+var _undefined = noop(); // Support ES3 engines
+
+var isValue = function isValue(val) {
+  return val !== _undefined && val !== null;
+};
+
+var keys = Object.keys;
+
+var shim = function shim(object) {
+	return keys(isValue(object) ? Object(object) : object);
+};
+
+var keys$1 = isImplemented$2() ? Object.keys : shim;
+
+var validValue = function validValue(value) {
+	if (!isValue(value)) throw new TypeError("Cannot use null or undefined");
+	return value;
+};
+
+var max = Math.max;
+
+var shim$1 = function shim(dest, src /*, …srcn*/) {
+	var error,
+	    i,
+	    length = max(arguments.length, 2),
+	    assign;
+	dest = Object(validValue(dest));
+	assign = function assign(key) {
+		try {
+			dest[key] = src[key];
+		} catch (e) {
+			if (!error) error = e;
+		}
+	};
+	for (i = 1; i < length; ++i) {
+		src = arguments[i];
+		keys$1(src).forEach(assign);
+	}
+	if (error !== undefined) throw error;
+	return dest;
+};
+
+var assign = isImplemented$1() ? Object.assign : shim$1;
+
+var forEach = Array.prototype.forEach,
+    create = Object.create;
+
+var process = function process(src, obj) {
+	var key;
+	for (key in src) {
+		obj[key] = src[key];
+	}
+};
+
+// eslint-disable-next-line no-unused-vars
+var normalizeOptions = function normalizeOptions(opts1 /*, …options*/) {
+	var result = create(null);
+	forEach.call(arguments, function (options) {
+		if (!isValue(options)) return;
+		process(Object(options), result);
+	});
+	return result;
+};
+
+// Deprecated
+
+var isCallable = function isCallable(obj) {
+  return typeof obj === "function";
+};
+
+var str = "razdwatrzy";
+
+var isImplemented$3 = function isImplemented() {
+	if (typeof str.contains !== "function") return false;
+	return str.contains("dwa") === true && str.contains("foo") === false;
+};
+
+var indexOf = String.prototype.indexOf;
+
+var shim$2 = function shim(searchString /*, position*/) {
+	return indexOf.call(this, searchString, arguments[1]) > -1;
+};
+
+var contains = isImplemented$3() ? String.prototype.contains : shim$2;
+
+var d_1 = createCommonjsModule(function (module) {
+
+	var d;
+
+	d = module.exports = function (dscr, value /*, options*/) {
+		var c, e, w, options, desc;
+		if (arguments.length < 2 || typeof dscr !== 'string') {
+			options = value;
+			value = dscr;
+			dscr = null;
+		} else {
+			options = arguments[2];
+		}
+		if (dscr == null) {
+			c = w = true;
+			e = false;
+		} else {
+			c = contains.call(dscr, 'c');
+			e = contains.call(dscr, 'e');
+			w = contains.call(dscr, 'w');
+		}
+
+		desc = { value: value, configurable: c, enumerable: e, writable: w };
+		return !options ? desc : assign(normalizeOptions(options), desc);
+	};
+
+	d.gs = function (dscr, get, set /*, options*/) {
+		var c, e, options, desc;
+		if (typeof dscr !== 'string') {
+			options = set;
+			set = get;
+			get = dscr;
+			dscr = null;
+		} else {
+			options = arguments[3];
+		}
+		if (get == null) {
+			get = undefined;
+		} else if (!isCallable(get)) {
+			options = get;
+			get = set = undefined;
+		} else if (set == null) {
+			set = undefined;
+		} else if (!isCallable(set)) {
+			options = set;
+			set = undefined;
+		}
+		if (dscr == null) {
+			c = true;
+			e = false;
+		} else {
+			c = contains.call(dscr, 'c');
+			e = contains.call(dscr, 'e');
+		}
+
+		desc = { get: get, set: set, configurable: c, enumerable: e };
+		return !options ? desc : assign(normalizeOptions(options), desc);
+	};
+});
+
+var isSymbol = function isSymbol(x) {
+	if (!x) return false;
+	if ((typeof x === 'undefined' ? 'undefined' : _typeof(x)) === 'symbol') return true;
+	if (!x.constructor) return false;
+	if (x.constructor.name !== 'Symbol') return false;
+	return x[x.constructor.toStringTag] === 'Symbol';
+};
+
+var validateSymbol = function validateSymbol(value) {
+	if (!isSymbol(value)) throw new TypeError(value + " is not a symbol");
+	return value;
+};
+
+var create$1 = Object.create,
+    defineProperties = Object.defineProperties,
+    defineProperty$1 = Object.defineProperty,
+    objPrototype = Object.prototype,
+    NativeSymbol,
+    SymbolPolyfill,
+    HiddenSymbol,
+    globalSymbols = create$1(null),
+    isNativeSafe;
+
+if (typeof Symbol === 'function') {
+	NativeSymbol = Symbol;
+	try {
+		String(NativeSymbol());
+		isNativeSafe = true;
+	} catch (ignore) {}
+}
+
+var generateName = function () {
+	var created = create$1(null);
+	return function (desc) {
+		var postfix = 0,
+		    name,
+		    ie11BugWorkaround;
+		while (created[desc + (postfix || '')]) {
+			++postfix;
+		}desc += postfix || '';
+		created[desc] = true;
+		name = '@@' + desc;
+		defineProperty$1(objPrototype, name, d_1.gs(null, function (value) {
+			// For IE11 issue see:
+			// https://connect.microsoft.com/IE/feedbackdetail/view/1928508/
+			//    ie11-broken-getters-on-dom-objects
+			// https://github.com/medikoo/es6-symbol/issues/12
+			if (ie11BugWorkaround) return;
+			ie11BugWorkaround = true;
+			defineProperty$1(this, name, d_1(value));
+			ie11BugWorkaround = false;
+		}));
+		return name;
+	};
+}();
+
+// Internal constructor (not one exposed) for creating Symbol instances.
+// This one is used to ensure that `someSymbol instanceof Symbol` always return false
+HiddenSymbol = function _Symbol(description) {
+	if (this instanceof HiddenSymbol) throw new TypeError('Symbol is not a constructor');
+	return SymbolPolyfill(description);
+};
+
+// Exposed `Symbol` constructor
+// (returns instances of HiddenSymbol)
+var polyfill = SymbolPolyfill = function _Symbol2(description) {
+	var symbol;
+	if (this instanceof _Symbol2) throw new TypeError('Symbol is not a constructor');
+	if (isNativeSafe) return NativeSymbol(description);
+	symbol = create$1(HiddenSymbol.prototype);
+	description = description === undefined ? '' : String(description);
+	return defineProperties(symbol, {
+		__description__: d_1('', description),
+		__name__: d_1('', generateName(description))
+	});
+};
+defineProperties(SymbolPolyfill, {
+	for: d_1(function (key) {
+		if (globalSymbols[key]) return globalSymbols[key];
+		return globalSymbols[key] = SymbolPolyfill(String(key));
+	}),
+	keyFor: d_1(function (s) {
+		var key;
+		validateSymbol(s);
+		for (key in globalSymbols) {
+			if (globalSymbols[key] === s) return key;
+		}
+	}),
+
+	// To ensure proper interoperability with other native functions (e.g. Array.from)
+	// fallback to eventual native implementation of given symbol
+	hasInstance: d_1('', NativeSymbol && NativeSymbol.hasInstance || SymbolPolyfill('hasInstance')),
+	isConcatSpreadable: d_1('', NativeSymbol && NativeSymbol.isConcatSpreadable || SymbolPolyfill('isConcatSpreadable')),
+	iterator: d_1('', NativeSymbol && NativeSymbol.iterator || SymbolPolyfill('iterator')),
+	match: d_1('', NativeSymbol && NativeSymbol.match || SymbolPolyfill('match')),
+	replace: d_1('', NativeSymbol && NativeSymbol.replace || SymbolPolyfill('replace')),
+	search: d_1('', NativeSymbol && NativeSymbol.search || SymbolPolyfill('search')),
+	species: d_1('', NativeSymbol && NativeSymbol.species || SymbolPolyfill('species')),
+	split: d_1('', NativeSymbol && NativeSymbol.split || SymbolPolyfill('split')),
+	toPrimitive: d_1('', NativeSymbol && NativeSymbol.toPrimitive || SymbolPolyfill('toPrimitive')),
+	toStringTag: d_1('', NativeSymbol && NativeSymbol.toStringTag || SymbolPolyfill('toStringTag')),
+	unscopables: d_1('', NativeSymbol && NativeSymbol.unscopables || SymbolPolyfill('unscopables'))
+});
+
+// Internal tweaks for real symbol producer
+defineProperties(HiddenSymbol.prototype, {
+	constructor: d_1(SymbolPolyfill),
+	toString: d_1('', function () {
+		return this.__name__;
+	})
+});
+
+// Proper implementation of methods exposed on Symbol.prototype
+// They won't be accessible on produced symbol instances as they derive from HiddenSymbol.prototype
+defineProperties(SymbolPolyfill.prototype, {
+	toString: d_1(function () {
+		return 'Symbol (' + validateSymbol(this).__description__ + ')';
+	}),
+	valueOf: d_1(function () {
+		return validateSymbol(this);
+	})
+});
+defineProperty$1(SymbolPolyfill.prototype, SymbolPolyfill.toPrimitive, d_1('', function () {
+	var symbol = validateSymbol(this);
+	if ((typeof symbol === 'undefined' ? 'undefined' : _typeof(symbol)) === 'symbol') return symbol;
+	return symbol.toString();
+}));
+defineProperty$1(SymbolPolyfill.prototype, SymbolPolyfill.toStringTag, d_1('c', 'Symbol'));
+
+// Proper implementaton of toPrimitive and toStringTag for returned symbol instances
+defineProperty$1(HiddenSymbol.prototype, SymbolPolyfill.toStringTag, d_1('c', SymbolPolyfill.prototype[SymbolPolyfill.toStringTag]));
+
+// Note: It's important to define `toPrimitive` as last one, as some implementations
+// implement `toPrimitive` natively without implementing `toStringTag` (or other specified symbols)
+// And that may invoke error in definition flow:
+// See: https://github.com/medikoo/es6-symbol/issues/13#issuecomment-164146149
+defineProperty$1(HiddenSymbol.prototype, SymbolPolyfill.toPrimitive, d_1('c', SymbolPolyfill.prototype[SymbolPolyfill.toPrimitive]));
+
+var es6Symbol = isImplemented() ? Symbol : polyfill;
+
+// @ts-nocheck
+if (!window.Symbol) window.Symbol = es6Symbol;
+
+})));

--- a/polyfills/native-shim.js
+++ b/polyfills/native-shim.js
@@ -4,6 +4,36 @@
 	(factory());
 }(this, (function () { 'use strict';
 
+var classCallCheck = function (instance, Constructor) {
+  if (!(instance instanceof Constructor)) {
+    throw new TypeError("Cannot call a class as a function");
+  }
+};
+
+var inherits = function (subClass, superClass) {
+  if (typeof superClass !== "function" && superClass !== null) {
+    throw new TypeError("Super expression must either be null or a function, not " + typeof superClass);
+  }
+
+  subClass.prototype = Object.create(superClass && superClass.prototype, {
+    constructor: {
+      value: subClass,
+      enumerable: false,
+      writable: true,
+      configurable: true
+    }
+  });
+  if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass;
+};
+
+var possibleConstructorReturn = function (self, call) {
+  if (!self) {
+    throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
+  }
+
+  return call && (typeof call === "object" || typeof call === "function") ? call : self;
+};
+
 // @ts-nocheck
 
 /**
@@ -69,7 +99,8 @@
 (function () {
 
   // Do nothing if `customElements` does not exist.
-  if (!window.customElements) { return; }
+
+  if (!window.customElements) return;
 
   var NativeHTMLElement = window.HTMLElement;
   var nativeDefine = window.customElements.define;
@@ -108,7 +139,7 @@
 
       // Make sure that the fake constructor doesn't call back to this constructor
       userConstruction = true;
-      var instance = new (fakeClass)(); // eslint-disable-line
+      var instance = new fakeClass(); // eslint-disable-line
       return instance;
     }
     // Else do nothing. This will be reached by ES5-style classes doing
@@ -122,34 +153,36 @@
   // ptototype chain of built-in elements.
   window.HTMLElement.prototype = NativeHTMLElement.prototype;
 
-  var define = function (tagname, elementClass) {
+  var define = function define(tagname, elementClass) {
     var elementProto = elementClass.prototype;
-    var StandInElement = (function (NativeHTMLElement) {
-      function StandInElement () {
-        // Call the native HTMLElement constructor, this gives us the
-        // under-construction instance as `this`:
-        NativeHTMLElement.call(this);
+    var StandInElement = function (_NativeHTMLElement) {
+      inherits(StandInElement, _NativeHTMLElement);
+
+      function StandInElement() {
+        classCallCheck(this, StandInElement);
 
         // The prototype will be wrong up because the browser used our fake
         // class, so fix it:
-        Object.setPrototypeOf(this, elementProto);
+        var _this = possibleConstructorReturn(this, (StandInElement.__proto__ || Object.getPrototypeOf(StandInElement)).call(this));
+        // Call the native HTMLElement constructor, this gives us the
+        // under-construction instance as `this`:
+
+
+        Object.setPrototypeOf(_this, elementProto);
 
         if (!userConstruction) {
           // Make sure that user-defined constructor bottom's out to a do-nothing
           // HTMLElement() call
           browserConstruction = true;
           // Call the user-defined constructor on our instance:
-          elementClass.call(this);
+          elementClass.call(_this);
         }
         userConstruction = false;
+        return _this;
       }
 
-      if ( NativeHTMLElement ) StandInElement.__proto__ = NativeHTMLElement;
-      StandInElement.prototype = Object.create( NativeHTMLElement && NativeHTMLElement.prototype );
-      StandInElement.prototype.constructor = StandInElement;
-
       return StandInElement;
-    }(NativeHTMLElement));
+    }(NativeHTMLElement);
     var standInProto = StandInElement.prototype;
     StandInElement.observedAttributes = elementClass.observedAttributes;
     standInProto.connectedCallback = elementProto.connectedCallback;
@@ -162,16 +195,15 @@
     nativeDefine.call(window.customElements, tagname, StandInElement);
   };
 
-  var get = function (tagname) { return constructorByTagname.get(tagname); };
+  var get$$1 = function get$$1(tagname) {
+    return constructorByTagname.get(tagname);
+  };
 
   // Workaround for Safari bug where patching customElements can be lost, likely
   // due to native wrapper garbage collection issue
-  Object.defineProperty(window, 'customElements',
-    {value: window.customElements, configurable: true, writable: true});
-  Object.defineProperty(window.customElements, 'define',
-    {value: define, configurable: true, writable: true});
-  Object.defineProperty(window.customElements, 'get',
-    {value: get, configurable: true, writable: true});
+  Object.defineProperty(window, 'customElements', { value: window.customElements, configurable: true, writable: true });
+  Object.defineProperty(window.customElements, 'define', { value: define, configurable: true, writable: true });
+  Object.defineProperty(window.customElements, 'get', { value: get$$1, configurable: true, writable: true });
 })();
 
 })));

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
-import buble from 'rollup-plugin-buble';
+import babel from 'rollup-plugin-babel';
 import uglify from 'rollup-plugin-uglify';
 import fs from 'fs';
 const output = [];
@@ -16,21 +16,30 @@ const testScriptFiles = fs.readdirSync('test/unit/scripts');
 const testCaseFiles = fs.readdirSync('test/unit/cases');
 
 output.push({
-  input: `lib/native-shim.js`,
+  input: `lib/es6-symbol.js`,
   output: {
-    file: `lib/native-shim.es5.js`,
+    file: `polyfills/es6-symbol.js`,
     format: 'umd',
     name: 'NativeShim'
   },
   plugins: [
     resolve(), // so Rollup can find `ms`
     commonjs(), // so Rollup can convert `ms` to an ES module
-    buble({ // transpile ES2015+ to ES5
-      transforms: {
-        templateString: false,
-        forOf: false
-      }
-    })
+    babel() // transpile ES2015+ to ES5
+  ]
+});
+
+output.push({
+  input: `lib/native-shim.js`,
+  output: {
+    file: `polyfills/native-shim.js`,
+    format: 'umd',
+    name: 'NativeShim'
+  },
+  plugins: [
+    resolve(), // so Rollup can find `ms`
+    commonjs(), // so Rollup can convert `ms` to an ES module
+    babel() // transpile ES2015+ to ES5
   ]
 });
 
@@ -45,12 +54,7 @@ for (let testFile of testScriptFiles) {
     plugins: [
       resolve(), // so Rollup can find `ms`
       commonjs(), // so Rollup can convert `ms` to an ES module
-      buble({ // transpile ES2015+ to ES5
-        transforms: {
-          templateString: false,
-          forOf: false
-        }
-      })
+      babel() // transpile ES2015+ to ES5
     ]
   });
 }
@@ -66,12 +70,7 @@ for (let testFile of testCaseFiles) {
     plugins: [
       resolve(), // so Rollup can find `ms`
       commonjs(), // so Rollup can convert `ms` to an ES module
-      buble({ // transpile ES2015+ to ES5
-        transforms: {
-          templateString: false,
-          forOf: false
-        }
-      })
+      babel() // transpile ES2015+ to ES5
     ]
   });
 }
@@ -115,13 +114,7 @@ for (let name of files) {
     plugins: [
       resolve(), // so Rollup can find `ms`
       commonjs(), // so Rollup can convert `ms` to an ES module
-      buble({ // transpile ES2015+ to ES5
-        exclude: ['node_modules/**'],
-        transforms: {
-          templateString: false,
-          forOf: false
-        }
-      })
+      babel() // transpile ES2015+ to ES5
     ]
   });
 
@@ -135,13 +128,7 @@ for (let name of files) {
     plugins: [
       resolve(), // so Rollup can find `ms`
       commonjs(), // so Rollup can convert `ms` to an ES module
-      buble({ // transpile ES2015+ to ES5
-        exclude: ['node_modules/**'],
-        transforms: {
-          templateString: false,
-          forOf: false
-        }
-      }),
+      babel(), // transpile ES2015+ to ES5,
       uglify()
     ]
   });
@@ -163,13 +150,7 @@ for (let name of files) {
       { file: `dist/${name}.esm.es5.js`, format: 'es' }
     ],
     plugins: [
-      buble({ // transpile ES2015+ to ES5
-        exclude: ['node_modules/**'],
-        transforms: {
-          templateString: false,
-          forOf: false
-        }
-      })
+      babel() // transpile ES2015+ to ES5
     ]
   });
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,6 +15,25 @@ const files = [
 const testScriptFiles = fs.readdirSync('test/unit/scripts');
 const testCaseFiles = fs.readdirSync('test/unit/cases');
 
+output.push({
+  input: `lib/native-shim.js`,
+  output: {
+    file: `lib/native-shim.es5.js`,
+    format: 'umd',
+    name: 'NativeShim'
+  },
+  plugins: [
+    resolve(), // so Rollup can find `ms`
+    commonjs(), // so Rollup can convert `ms` to an ES module
+    buble({ // transpile ES2015+ to ES5
+      transforms: {
+        templateString: false,
+        forOf: false
+      }
+    })
+  ]
+});
+
 for (let testFile of testScriptFiles) {
   output.push({
     input: `test/unit/scripts/${testFile}`,

--- a/test/runner.ie.es5.html
+++ b/test/runner.ie.es5.html
@@ -1,0 +1,26 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script>
+      WCT = {
+        mochaOptions: {
+          timeout: 60000
+        }
+      }
+    </script>
+    <script src="../../../wct-browser-legacy/browser.js"></script>
+  </head>
+  <body>
+    <script>
+      'use script';
+
+      let suites = [
+        './unit/element-lite-base.ie.es5.test.html',
+        './unit/element-lite-lit-only.ie.es5.test.html',
+        './unit/element-lite.ie.es5.test.html'
+      ];
+
+      WCT.loadSuites(suites);
+    </script>
+  </body>
+</html>

--- a/test/unit/cases/element-lite-lit-only.test.js
+++ b/test/unit/cases/element-lite-lit-only.test.js
@@ -17,7 +17,7 @@ suite('ElementLiteLitOnly Mixin', () => {
 
   test('button can be clicked', done => {
     const el = document.createElement('test-element-two');
-    document.body.append(el);
+    document.body.appendChild(el);
     const button = el.shadowRoot.querySelector('#button');
     expect(button).to.exist;
     MockInteractions.tap(button);
@@ -30,7 +30,7 @@ suite('ElementLiteLitOnly Mixin', () => {
 
   test('button style is changed', () => {
     const el = document.createElement('test-element-two');
-    document.body.append(el);
+    document.body.appendChild(el);
     const button = el.shadowRoot.querySelector('#button');
     expect(button).to.exist;
     expect(button.getBoundingClientRect().width).to.equal(500);

--- a/test/unit/cases/element-lite.test.js
+++ b/test/unit/cases/element-lite.test.js
@@ -47,7 +47,7 @@ suite('ElementLite Mixin', () => {
 
   test('button style is changed', () => {
     const el = document.createElement('test-element-three');
-    document.body.append(el);
+    document.body.appendChild(el);
     const button = el.shadowRoot.querySelector('#button');
     expect(button).to.exist;
     expect(button.getBoundingClientRect().width).to.equal(500);

--- a/test/unit/element-lite-base.browser.es5.test.html
+++ b/test/unit/element-lite-base.browser.es5.test.html
@@ -5,7 +5,7 @@
     <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../../../@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
     <script src="../../../../wct-browser-legacy/browser.js"></script>
-    <script src="./polyfills/find-index.js"></script>
+    <script src="../../polyfills/find-index.js"></script>
   </head>
   <body>
 

--- a/test/unit/element-lite-base.browser.es5.test.html
+++ b/test/unit/element-lite-base.browser.es5.test.html
@@ -11,18 +11,7 @@
 
     <test-element id="test" prop1="a" prop2="b"></test-element>
 
-    <script>
-      window.addEventListener('WebComponentsReady', function() {
-        var component = document.createElement('script');
-        component.src = './scripts-es5/element-lite-base.test.js';
-        document.head.appendChild(component);
-
-        setTimeout(function() {
-          var cases = document.createElement('script');
-          cases.src = './cases-es5/element-lite-base.test.js';
-          document.head.appendChild(cases);
-        }, 200);
-      });
-    </script>
+    <script src="./scripts-es5/element-lite-base.test.js"></script>
+    <script src="./cases-es5/element-lite-base.test.js"></script>
   </body>
 </html>

--- a/test/unit/element-lite-base.ie.es5.test..html
+++ b/test/unit/element-lite-base.ie.es5.test..html
@@ -1,0 +1,17 @@
+<!doctype html>
+  <html>
+  <head>
+    <meta charset="utf-8">
+    <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../lib/native-shim.es5.js"></script>
+    <script src="../../../../wct-browser-legacy/browser.js"></script>
+    <script src="./polyfills/find-index.js"></script>
+  </head>
+  <body>
+
+    <test-element id="test" prop1="a" prop2="b"></test-element>
+
+    <script src="./scripts-es5/element-lite-base.test.js"></script>
+    <script src="./cases-es5/element-lite-base.test.js"></script>
+  </body>
+</html>

--- a/test/unit/element-lite-base.ie.es5.test..html
+++ b/test/unit/element-lite-base.ie.es5.test..html
@@ -5,7 +5,7 @@
     <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../lib/native-shim.es5.js"></script>
     <script src="../../../../wct-browser-legacy/browser.js"></script>
-    <script src="./polyfills/find-index.js"></script>
+    <script src="../../polyfills/find-index.js"></script>
   </head>
   <body>
 

--- a/test/unit/element-lite-lit-only.browser.es5.test.html
+++ b/test/unit/element-lite-lit-only.browser.es5.test.html
@@ -12,18 +12,7 @@
 
     <test-element-two id="test"></test-element-two>
 
-    <script>
-      window.addEventListener('WebComponentsReady', function() {
-        var component = document.createElement('script');
-        component.src = './scripts-es5/element-lite-lit-only.test.js';
-        document.head.appendChild(component);
-
-        setTimeout(function() {
-          var cases = document.createElement('script');
-          cases.src = './cases-es5/element-lite-lit-only.test.js';
-          document.head.appendChild(cases);
-        }, 200);
-      });
-    </script>
+    <script src="./scripts-es5/element-lite-lit-only.test.js"></script>
+    <script src="./cases-es5/element-lite-lit-only.test.js"></script>
   </body>
 </html>

--- a/test/unit/element-lite-lit-only.browser.es5.test.html
+++ b/test/unit/element-lite-lit-only.browser.es5.test.html
@@ -6,7 +6,7 @@
     <script src="../../../../@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
     <script src="../../../../wct-browser-legacy/browser.js"></script>
     <script src="../../../../@polymer/iron-test-helpers/mock-interactions.js"></script>
-    <script src="./polyfills/find-index.js"></script>
+    <script src="../../polyfills/find-index.js"></script>
   </head>
   <body>
 

--- a/test/unit/element-lite-lit-only.ie.es5.test.html
+++ b/test/unit/element-lite-lit-only.ie.es5.test.html
@@ -6,7 +6,7 @@
     <script src="../../lib/native-shim.es5.js"></script>
     <script src="../../../../wct-browser-legacy/browser.js"></script>
     <script src="../../../../@polymer/iron-test-helpers/mock-interactions.js"></script>
-    <script src="./polyfills/find-index.js"></script>
+    <script src="../../polyfills/find-index.js"></script>
   </head>
   <body>
 

--- a/test/unit/element-lite-lit-only.ie.es5.test.html
+++ b/test/unit/element-lite-lit-only.ie.es5.test.html
@@ -1,0 +1,18 @@
+<!doctype html>
+  <html>
+  <head>
+    <meta charset="utf-8">
+    <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../lib/native-shim.es5.js"></script>
+    <script src="../../../../wct-browser-legacy/browser.js"></script>
+    <script src="../../../../@polymer/iron-test-helpers/mock-interactions.js"></script>
+    <script src="./polyfills/find-index.js"></script>
+  </head>
+  <body>
+
+    <test-element-two id="test"></test-element-two>
+
+    <script src="./scripts-es5/element-lite-lit-only.test.js"></script>
+    <script src="./cases-es5/element-lite-lit-only.test.js"></script>
+  </body>
+</html>

--- a/test/unit/element-lite.browser.es5.test.html
+++ b/test/unit/element-lite.browser.es5.test.html
@@ -12,18 +12,7 @@
 
     <test-element-three id="test"></test-element-three>
 
-    <script>
-      window.addEventListener('WebComponentsReady', function() {
-        var component = document.createElement('script');
-        component.src = './scripts-es5/element-lite.test.js';
-        document.head.appendChild(component);
-
-        setTimeout(function() {
-          var cases = document.createElement('script');
-          cases.src = './cases-es5/element-lite.test.js';
-          document.head.appendChild(cases);
-        }, 200);
-      });
-    </script>
+    <script src="./scripts-es5/element-lite.test.js"></script>
+    <script src="./cases-es5/element-lite.test.js"></script>
   </body>
 </html>

--- a/test/unit/element-lite.browser.es5.test.html
+++ b/test/unit/element-lite.browser.es5.test.html
@@ -6,7 +6,7 @@
     <script src="../../../../@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
     <script src="../../../../wct-browser-legacy/browser.js"></script>
     <script src="../../../../@polymer/iron-test-helpers/mock-interactions.js"></script>
-    <script src="./polyfills/find-index.js"></script>
+    <script src="../../polyfills/find-index.js"></script>
   </head>
   <body>
 

--- a/test/unit/element-lite.ie.es5.test.html
+++ b/test/unit/element-lite.ie.es5.test.html
@@ -6,7 +6,7 @@
     <script src="../../lib/native-shim.es5.js"></script>
     <script src="../../../../wct-browser-legacy/browser.js"></script>
     <script src="../../../../@polymer/iron-test-helpers/mock-interactions.js"></script>
-    <script src="./polyfills/find-index.js"></script>
+    <script src="../../polyfills/find-index.js"></script>
   </head>
   <body>
 

--- a/test/unit/element-lite.ie.es5.test.html
+++ b/test/unit/element-lite.ie.es5.test.html
@@ -1,0 +1,18 @@
+<!doctype html>
+  <html>
+  <head>
+    <meta charset="utf-8">
+    <script src="../../../../@webcomponents/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../../lib/native-shim.es5.js"></script>
+    <script src="../../../../wct-browser-legacy/browser.js"></script>
+    <script src="../../../../@polymer/iron-test-helpers/mock-interactions.js"></script>
+    <script src="./polyfills/find-index.js"></script>
+  </head>
+  <body>
+
+    <test-element-three id="test"></test-element-three>
+
+    <script src="./scripts-es5/element-lite.test.js"></script>
+    <script src="./cases-es5/element-lite.test.js"></script>
+  </body>
+</html>

--- a/wct-sauce-ie.conf.json
+++ b/wct-sauce-ie.conf.json
@@ -1,0 +1,16 @@
+{
+  "suites": ["test/runner.ie.es5.html"],
+  "verbose": false,
+  "quiet": true,
+  "plugins": {
+    "sauce": {
+      "browsers": [
+        {
+          "browserName": "internet explorer",
+          "platform": "Windows 8.1",
+          "version": "11"
+        }
+      ]
+    }
+  }
+}

--- a/wct-sauce.conf.json
+++ b/wct-sauce.conf.json
@@ -19,16 +19,6 @@
           "browserName": "safari",
           "platform": "OS X 10.12",
           "version": "10.1"
-        },
-        {
-          "browserName": "safari",
-          "platform": "OS X 10.11",
-          "version": "9"
-        },
-        {
-          "browserName": "safari",
-          "platform": "OS X 10.10",
-          "version": "8"
         }
       ]
     }

--- a/wct-sauce.conf.json
+++ b/wct-sauce.conf.json
@@ -11,11 +11,6 @@
           "version": ""
         },
         {
-          "browserName": "internet explorer",
-          "platform": "Windows 8.1",
-          "version": "11"
-        },
-        {
           "browserName": "safari",
           "platform": "OS X 10.13",
           "version": "11"


### PR DESCRIPTION
Signed-off-by: Toni-Jan Keith Monserrat <tonijanmonserrat@gmail.com>

<!-- Instructions: https://github.com/tjmonsi/element-lite/blob/master/CONTRIBUTING.md#pull-requests -->

## Description
This is to make it easier for us to import element-lite without worrying about installation procedures on node_modules (especially when working on it). But if you are just downloading this and then not using npm, then use the files in dist.

<!-- @mentions people from the team who you would like to check this pull request -->